### PR TITLE
Fixes RubyForge link

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,6 +1,6 @@
 = ruby-growl
 
-* http://ruby-growl.rubyforge.org/ruby-growl
+* http://ruby-growl.rubyforge.org/
 
 == DESCRIPTION:
 


### PR DESCRIPTION
I think you somehow merged http://rubyforge.org/projects/ruby-growl/ and http://ruby-growl.rubyforge.org/ into one URL.  ;)
