### PR TITLE
Support UTF-8 strings

### DIFF
--- a/lib/ruby-growl/gntp.rb
+++ b/lib/ruby-growl/gntp.rb
@@ -299,7 +299,7 @@ class Growl::GNTP
 
     if @encrypt == 'NONE' then
       packet << ["GNTP/1.0", type, "NONE", key_info].compact.join(' ')
-      packet << body
+      packet << body.force_encoding("ASCII-8BIT")
     else
       encipher, iv = cipher key
 


### PR DESCRIPTION
Fix bug for utf-8.

``` ruby
# -*- encoding: utf-8 -*-
require 'ruby-growl'
require 'ruby-growl/ruby_logo'

g = Growl.new "localhost", "ruby-growl"
g.add_notification("notification", "ruby-growl Notification",
                   Growl::RUBY_LOGO_PNG)
g.notify "notification", "It came from ruby-growl", "UTF-8の文字列を送信"
```

```
/Users/kunigaku/src/ruby-growl/lib/ruby-growl/gntp.rb:336:in `join': incompatible character encodings: UTF-8 and ASCII-8BIT (Encoding::CompatibilityError)
    from /Users/kunigaku/src/ruby-growl/lib/ruby-growl/gntp.rb:336:in `packet'
    from /Users/kunigaku/src/ruby-growl/lib/ruby-growl/gntp.rb:376:in `packet_notify'
    from /Users/kunigaku/src/ruby-growl/lib/ruby-growl/gntp.rb:269:in `notify'
    from /Users/kunigaku/src/ruby-growl/lib/ruby-growl.rb:305:in `notify_gntp'
    from /Users/kunigaku/src/ruby-growl/lib/ruby-growl.rb:285:in `notify'
    from rg.rb:8:in `<main>'
```
