### PR TITLE
Update ruby interpreter path

### DIFF
--- a/bin/growl
+++ b/bin/growl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/ruby
+#!/usr/bin/ruby
 
 require 'ruby-growl'
 


### PR DESCRIPTION
Updates the ruby interpreter path from `/usr/local/bin/ruby` to `/usr/bin/ruby`
Closes #18 